### PR TITLE
unifies how we extract samples from multivalued functions

### DIFF
--- a/bin/extract-samples
+++ b/bin/extract-samples
@@ -79,7 +79,7 @@ ans = samples.data2samples(
     args.reference_value,
     selection_rule=args.selection_rule,
     branches_mapping=args.branches,
-    default_values=[args.default_value[col] for col in args.columns],
+    default_values=[default_value[col] for col in args.columns],
 )
 
 outcols = samples.output_columns(args.columns, args.reference, reference_values=args.reference_value)

--- a/bin/extract-samples
+++ b/bin/extract-samples
@@ -8,6 +8,8 @@ __author__ = "Reed Essick (reed.essick@gmail.com)"
 
 from argparse import ArgumentParser
 
+from universality.properties import samples
+
 #-------------------------------------------------
 
 parser = ArgumentParser(description=__doc__)
@@ -25,8 +27,11 @@ rgroup.add_argument('columns', nargs='+', type=str,
 rgroup.add_argument('-r', '--reference-value', default=[], type=float, action='append',
     help='the reference values at which we extract values from the EOS parameters. \
 DEFAULT=[]')
-rgroup.add_argument('--nearest-neighbor', default=False, action='store_true',
-    help='if supplied, we take the nearest neighbor when looking up the sample instead of interpolation (which may fail if the curve is not monotonic)')
+
+rgroup.add_argument('--selection-rule', default=samples.DEFAULT_SELECTION_RULE, type=str)
+rgroup.add_argument('--branches', nargs=4, type=str, default=None,
+    help='eg "--branches path affine start stop"')
+rgroup.add_argument('--default-value', nargs=2, type=str, default=[], action='append')
 
 # verbosity arguments
 vgroup = parser.add_argument_group('verbosity arguments')
@@ -44,6 +49,11 @@ args.reference_value.sort()
 
 if os.path.dirname(args.outpath) and (not os.path.exists(os.path.dirname(args.outpath))):
     os.makedirs(os.path.dirname(args.outpath))
+
+default_value = dict((key, float(val)) for key, val in args.default_value)
+if args.branches is not None:
+    for column in args.columns:
+        assert column in default_value, 'must specify --default-value for column=%s when --branches-basename is not None'%column
 
 #-------------------------------------------------
 
@@ -66,9 +76,10 @@ ans = np.empty((N, Nref*Ncol), dtype=float)
 ans = samples.data2samples(
     x,
     data,
-    (Nref, args.reference_value),
-    (0, None), ### not used
-    nearest_neighbor=args.nearest_neighbor,
+    args.reference_value,
+    selection_rule=args.selection_rule,
+    branches_mapping=args.branches,
+    default_values=[args.default_value[col] for col in args.columns],
 )
 
 outcols = samples.output_columns(args.columns, args.reference, reference_values=args.reference_value)

--- a/bin/plot-process
+++ b/bin/plot-process
@@ -58,6 +58,8 @@ along with column names to map the parameters in the eos files (--eos-basename) 
 Note that the column used to look up branches should be monotonically increasing so that it uniquely defines each branch according to the contained range. \
 eg "--branches-basename \'label branches_summary_template baryon_density start_central_baryon_density end_central_baryon_density"')
 
+rgroup.add_argument('--branches-dir', nargs=2, type=str, default=[], action='append')
+
 rgroup.add_argument('--default-y-value', default=None, type=float)
 
 rgroup.add_argument('--overlay-samples', nargs=2, type=str, default=[], action='append',
@@ -255,10 +257,15 @@ for label, column in args.eos_column:
     assert label in names, 'specifying --eos-column for unknown sample set: '+label
     eos_columns[label] = column
 
+branches_dirs = dict((label, eos_dirs[label]) for label in names:
+for label, directory in args.branches_dir:
+    assert label in names, 'specifying --branches-dir for unknown sample set: '+label
+    branches_dirs[label] = directory
+
 branches_mappings= dict((label, None) for label in names)
 for label, basename, affine, start, stop in args.branches_basename:
     assert label in names, 'specifying --branches-basename for unknown sample set: '+label
-    basename = os.path.join(eos_dirs[label], 'DRAWmod%d'%eos_num_per_dir[label]+'-%(moddraw)06d', basename)
+    basename = os.path.join(branches_dirs[label], 'DRAWmod%d'%eos_num_per_dir[label]+'-%(moddraw)06d', basename)
     branches_mappings[label] = basename, affine, start, stop
 
 # verbosity options

--- a/bin/plot-process
+++ b/bin/plot-process
@@ -37,8 +37,8 @@ rgroup = parser.add_argument_group('required arguments')
 rgroup.add_argument('-s', '--samples', required=True, nargs=2, default=[], type=str, action='append',
     help='e.g.: "--samples label path/to/samples.csv"')
 
-rgroup.add_argument('ycolumn', type=str)
 rgroup.add_argument('xcolumn', type=str)
+rgroup.add_argument('ycolumn', type=str)
 
 rgroup.add_argument('xmin', type=float)
 rgroup.add_argument('xmax', type=float)
@@ -48,11 +48,11 @@ rgroup.add_argument('--y-multiplier', default=1, type=str,
 rgroup.add_argument('--x-multiplier', default=1, type=str,
     help='multiply all x-values by this before plotting. x-limits are applied after multiplying.')
 
-rgroup.add_argument('--selection-rule', default=samples.DEFAULT_SELECTION_RULE, type=str,
+rgroup.add_argument('--selection-rule', nargs=2, default=[], action='append', type=str,
     help='the rule used to choose between multiple values if the the curves are not one-to-one. \
 Must be one of: %s'%(', '.join(samples.KNOWN_SELECTION_RULES)))
 
-rgroup.add_argument('--branches-basename', nargs=5, type=str, default=None,
+rgroup.add_argument('--branches-basename', nargs=5, type=str, default=[], action='append',
     help='if specified, will only select from stable branches. This must be a basename template that points to a summary of stable branches \
 along with column names to map the parameters in the eos files (--eos-basename) to the start/end parameters in the branches summary. \
 Note that the column used to look up branches should be monotonically increasing so that it uniquely defines each branch according to the contained range. \
@@ -256,6 +256,11 @@ eos_columns = dict((label, DEFAULT_EOS_COLUMN) for label in names)
 for label, column in args.eos_column:
     assert label in names, 'specifying --eos-column for unknown sample set: '+label
     eos_columns[label] = column
+
+selection_rules = dict((label, samples.DEFAULT_SELECTION_RULE) for label in names)
+for label, rule in args.selection_rule:
+    assert label in names, 'specifying --selection-rule for unknown sample set: '+label
+    selection_rules[label] = rule
 
 branches_dirs = dict((label, eos_dirs[label]) for label in names)
 for label, directory in args.branches_dir:
@@ -485,7 +490,7 @@ for ind, (label, path) in enumerate(args.samples):
             x_multiplier=args.x_multiplier,
             y_multiplier=args.y_multiplier,
             weights=weights,
-            selection_rule=args.selection_rule,
+            selection_rule=selection_rules[label],
             branches_mapping=branches_mappings[label],
             default_y_value=args.default_y_value,
             verbose=args.Verbose,

--- a/bin/plot-process
+++ b/bin/plot-process
@@ -48,6 +48,16 @@ rgroup.add_argument('--y-multiplier', default=1, type=str,
 rgroup.add_argument('--x-multiplier', default=1, type=str,
     help='multiply all x-values by this before plotting. x-limits are applied after multiplying.')
 
+rgroup.add_argument('--selection-rule', default=samples.DEFAULT_SELECTION_RULE, type=str,
+    help='the rule used to choose between multiple values if the the curves are not one-to-one. \
+Must be one of: %s'%(', '.join(samples.KNOWN_SELECTION_RULES)))
+
+rgroup.add_argument('--branches-basename', nargs=5, type=str, default=None,
+    help='if specified, will only select from stable branches. This must be a basename template that points to a summary of stable branches \
+along with column names to map the parameters in the eos files (--eos-basename) to the start/end parameters in the branches summary. \
+Note that the column used to look up branches should be monotonically increasing so that it uniquely defines each branch according to the contained range. \
+eg "--branches-basename \'label branches_summary_template baryon_density start_central_baryon_density end_central_baryon_density"')
+
 rgroup.add_argument('--default-y-value', default=None, type=float)
 
 rgroup.add_argument('--overlay-samples', nargs=2, type=str, default=[], action='append',
@@ -244,6 +254,12 @@ eos_columns = dict((label, DEFAULT_EOS_COLUMN) for label in names)
 for label, column in args.eos_column:
     assert label in names, 'specifying --eos-column for unknown sample set: '+label
     eos_columns[label] = column
+
+branches_mappings= dict((label, None) for label in names)
+for label, basename, affine, start, stop in args.branches_basename:
+    assert label in names, 'specifying --branches-basename for unknown sample set: '+label
+    basename = os.path.join(eos_dirs[label], 'DRAWmod%d'%eos_num_per_dir[label]+'-%(moddraw)06d', basename)
+    branches_mappings[label] = basename, affine, start, stop
 
 # verbosity options
 args.verbose |= args.Verbose
@@ -462,6 +478,8 @@ for ind, (label, path) in enumerate(args.samples):
             x_multiplier=args.x_multiplier,
             y_multiplier=args.y_multiplier,
             weights=weights,
+            selection_rule=args.selection_rule,
+            branches_mapping=branches_mappings[label],
             default_y_value=args.default_y_value,
             verbose=args.Verbose,
         )

--- a/bin/plot-process
+++ b/bin/plot-process
@@ -257,7 +257,7 @@ for label, column in args.eos_column:
     assert label in names, 'specifying --eos-column for unknown sample set: '+label
     eos_columns[label] = column
 
-branches_dirs = dict((label, eos_dirs[label]) for label in names:
+branches_dirs = dict((label, eos_dirs[label]) for label in names)
 for label, directory in args.branches_dir:
     assert label in names, 'specifying --branches-dir for unknown sample set: '+label
     branches_dirs[label] = directory

--- a/bin/process2quantiles
+++ b/bin/process2quantiles
@@ -46,6 +46,8 @@ along with column names to map the parameters in the eos files (--eos-basename) 
 Note that the column used to look up branches should be monotonically increasing so that it uniquely defines each branch according to the contained range. \
 eg "--branches-basename \'branches_summary_template baryon_density start_central_baryon_density end_central_baryon_density"')
 
+rgroup.add_argument('--branches-dir', type=str, default=None)
+
 rgroup.add_argument('--default-y-value', default=None, type=float)
 
 # verbosity arguments
@@ -93,6 +95,9 @@ else:
     args.quantile.sort()
 Nquantiles = len(args.quantile)
 
+if args.branches_dir is None:
+    args.branches_dir = args.eos_dir
+
 #-------------------------------------------------
 
 if args.verbose:
@@ -134,7 +139,7 @@ if args.verbose:
 path_template = os.path.join(args.eos_dir, 'DRAWmod%d'%args.eos_num_per_dir+'-%(moddraw)06d', args.eos_basename)
 if args.branches_basename is not None:
     basename, affine, start, stop = args.branches_basename
-    branches_mapping = os.path.join(args.eos_dir, 'DRAWmod%d'%args.eos_num_per_dir+'-%(moddraw)06d', basename), affine, start, stop
+    branches_mapping = os.path.join(args.branches_dir, 'DRAWmod%d'%args.eos_num_per_dir+'-%(moddraw)06d', basename), affine, start, stop
 else:
     branches_mapping = None
 

--- a/bin/process2quantiles
+++ b/bin/process2quantiles
@@ -36,6 +36,16 @@ rgroup.add_argument('xmax', type=float)
 rgroup.add_argument('--quantile', default=[], type=float, action='append',
     help='generate these quantiles. DEFAULT is each percentile between 0 and 100.')
 
+rgroup.add_argument('--selection-rule', default=samples.DEFAULT_SELECTION_RULE, type=str,
+    help='the rule used to choose between multiple values if the the curves are not one-to-one. \
+Must be one of: %s'%(', '.join(samples.KNOWN_SELECTION_RULES)))
+
+rgroup.add_argument('--branches-basename', nargs=4, type=str, default=None,
+    help='if specified, will only select from stable branches. This must be a basename template that points to a summary of stable branches \
+along with column names to map the parameters in the eos files (--eos-basename) to the start/end parameters in the branches summary. \
+Note that the column used to look up branches should be monotonically increasing so that it uniquely defines each branch according to the contained range. \
+eg "--branches-basename \'branches_summary_template baryon_density start_central_baryon_density end_central_baryon_density"')
+
 rgroup.add_argument('--default-y-value', default=None, type=float)
 
 # verbosity arguments
@@ -122,6 +132,11 @@ if args.verbose:
     print('extacting data and computing quantiles')
 
 path_template = os.path.join(args.eos_dir, 'DRAWmod%d'%args.eos_num_per_dir+'-%(moddraw)06d', args.eos_basename)
+if args.branches_basename is not None:
+    basename, affine, start, stop = args.branches_basename
+    branches_mapping = os.path.join(args.eos_dir, 'DRAWmod%d'%args.eos_num_per_dir+'-%(moddraw)06d', basename), affine, start, stop
+else:
+    branches_mapping = None
 
 ans = np.empty((Nquantiles, 1+args.num_points), dtype=float)
 ans[:,0] = args.quantile
@@ -135,6 +150,8 @@ ans[:,1:], _ = samples.process2quantiles(
     args.quantile,
     quantile_type='sym',
     weights=weights,
+    selection_rule=args.selection_rule,
+    branches_mapping=branches_mapping,
     default_y_value=args.default_y_value,
     verbose=args.Verbose,
 )

--- a/bin/process2samples
+++ b/bin/process2samples
@@ -46,6 +46,8 @@ along with column names to map the parameters in the eos files (--eos-basename) 
 Note that the column used to look up branches should be monotonically increasing so that it uniquely defines each branch according to the contained range. \
 eg "--branches-basename \'branches_summary_template baryon_density start_central_baryon_density end_central_baryon_density"')
 
+rgroup.add_argument('--branches-dir', default=None, type=str)
+
 rgroup.add_argument('--default-value', nargs=2, type=str, action='append', default=[],
     help='the default value to return if the reference is not on a stable branch but --select-from-stable-branches is specified. \
 Should be specified separately for each column that we wish to extract. eg "--default-value Lambda 0.0"')
@@ -85,9 +87,12 @@ args.reference_value.sort()
 assert args.selection_rule in samples.KNOWN_SELECTION_RULES, '--selection-rule must be one of: %s'%(', '.join(samples.KNOWN_SELECTION_RULES))
 
 default_value = dict((key, float(val)) for key, val in args.default_value)
-if args.branches_basename is not None:
+if (args.branches_basename is not None) and (args.selection_rule != 'nearest_neighbor'):
     for column in args.columns:
-        assert column in default_value, 'must specify --default-value for column=%s when --branches-basename is not None'%column
+        assert column in default_value, 'must specify --default-value for column=%s when --branches-basename is not None unless --selection-rule=nearest_neighbor'%column
+
+if args.branches_dir is None:
+    args.branches_dir = args.eos_dir ### fall back if not specified otherwise
 
 if os.path.dirname(args.outpath) and (not os.path.exists(os.path.dirname(args.outpath))):
     os.makedirs(os.path.dirname(args.outpath))
@@ -134,7 +139,7 @@ ans[:,:Nkeep+1] = keep ### fill in existing data
 path_template = os.path.join(args.eos_dir, 'DRAWmod%d'%args.eos_num_per_dir+'-%(moddraw)06d', args.eos_basename)
 if args.branches_basename is not None:
     basename, affine, start, stop = args.branches_basename
-    branches_mapping = os.path.join(args.eos_dir, 'DRAWmod%d'%args.eos_num_per_dir+'-%(moddraw)06d', basename), affine, start, stop
+    branches_mapping = os.path.join(args.branches_dir, 'DRAWmod%d'%args.eos_num_per_dir+'-%(moddraw)06d', basename), affine, start, stop
 else:
     branches_mapping = None
 
@@ -149,7 +154,7 @@ ans[:,Nkeep+1:] = samples.process2samples(
     verbose=args.Verbose,
     selection_rule=args.selection_rule,
     branches_mapping=branches_mapping,
-    default_values=[args.default_values[col] for col in args.columns],
+    default_values=[default_value.get(col, None) for col in args.columns],
 )
 
 ### set up output columns

--- a/bin/process2samples
+++ b/bin/process2samples
@@ -132,6 +132,11 @@ ans = np.empty((N, 1+Nkeep+Nref*Ncol), dtype=float)
 ans[:,:Nkeep+1] = keep ### fill in existing data
 
 path_template = os.path.join(args.eos_dir, 'DRAWmod%d'%args.eos_num_per_dir+'-%(moddraw)06d', args.eos_basename)
+if args.branches_basename is not None:
+    basename, affine, start, stop = args.branches_basename
+    branches_mapping = os.path.join(args.eos_dir, 'DRAWmod%d'%args.eos_num_per_dir+'-%(moddraw)06d', basename), affine, start, stop
+else:
+    branches_mapping = None
 
 ans[:,Nkeep+1:] = samples.process2samples(
     data,
@@ -143,7 +148,7 @@ ans[:,Nkeep+1:] = samples.process2samples(
     dynamic_x_test=ref,
     verbose=args.Verbose,
     selection_rule=args.selection_rule,
-    branches_mapping=args.branches_template,
+    branches_mapping=branches_mapping,
     default_values=[args.default_values[col] for col in args.columns],
 )
 

--- a/bin/process2samples
+++ b/bin/process2samples
@@ -35,8 +35,20 @@ DEFAULT=[]')
 rgroup.add_argument('-R', '--reference-value-column', default=[], type=str, action='append',
     help='look up the reference value from this column in the input data')
 
-rgroup.add_argument('--nearest-neighbor', default=False, action='store_true',
-    help='if supplied, we take the nearest neighbor when looking up the sample instead of interpolation (which may fail if the curve is not monotonic)')
+
+rgroup.add_argument('--selection-rule', default=samples.DEFAULT_SELECTION_RULE, type=str,
+    help='the rule used to choose between multiple values if the the curves are not one-to-one. \
+Must be one of: '%(', '.join(samples.KNOWN_SELECTION_RULES)))
+
+rgroup.add_argument('--branches-basename', nargs=4, type=str, default=None,
+    help='if specified, will only select from stable branches. This must be a basename template that points to a summary of stable branches \
+along with column names to map the parameters in the eos files (--eos-basename) to the start/end parameters in the branches summary. \
+Note that the column used to look up branches should be monotonically increasing so that it uniquely defines each branch according to the contained range. \
+eg "--branches-basename \'macro-draw-%(draw)06d-branches.csv baryon_density start_central_baryon_density end_central_baryon_density"')
+    help='only select from stable branches. Primarily relevant when looking at multivalued curves')
+rgroup.add_argument('--default-value', nargs=2, type=str, action='append', default=[],
+    help='the default value to return if the reference is not on a stable branch but --select-from-stable-branches is specified. \
+Should be specified separately for each column that we wish to extract. eg "--default-value Lambda 0.0"')
 
 rgroup.add_argument('-c', '--copy-column', default=[], type=str, action='append',
     help='copy over the values from this column. Can be repeated to specify multiple columns. If not specified, will copy over all columns by default.')
@@ -69,6 +81,13 @@ Ncol = len(args.columns)
 Nref = len(args.reference_value)+len(args.reference_value_column)
 Nkeep = len(args.copy_column)
 args.reference_value.sort()
+
+assert args.selection_rule in samples.KNOWN_SELECTION_RULES, '--selection-rule must be one of: %s'%(', '.join(samples.KNOWN_SELECTION_RULES))
+
+default_value = dict((key, float(val)) for key, val in args.default_value)
+if args.branches_basename is not None:
+    for column in args.columns:
+        assert column in default_value, 'must specify --default-value for column=%s when --branches-basename is not None'%column
 
 if os.path.dirname(args.outpath) and (not os.path.exists(os.path.dirname(args.outpath))):
     os.makedirs(os.path.dirname(args.outpath))
@@ -123,7 +142,9 @@ ans[:,Nkeep+1:] = samples.process2samples(
     static_x_test=args.reference_value,
     dynamic_x_test=ref,
     verbose=args.Verbose,
-    nearest_neighbor=args.nearest_neighbor,
+    selection_rule=args.selection_rule,
+    branches_mapping=args.branches_template,
+    default_values=args.default_values,
 )
 
 ### set up output columns

--- a/bin/process2samples
+++ b/bin/process2samples
@@ -87,9 +87,9 @@ args.reference_value.sort()
 assert args.selection_rule in samples.KNOWN_SELECTION_RULES, '--selection-rule must be one of: %s'%(', '.join(samples.KNOWN_SELECTION_RULES))
 
 default_value = dict((key, float(val)) for key, val in args.default_value)
-if (args.branches_basename is not None) and (args.selection_rule != 'nearest_neighbor'):
+if (args.branches_basename is not None):
     for column in args.columns:
-        assert column in default_value, 'must specify --default-value for column=%s when --branches-basename is not None unless --selection-rule=nearest_neighbor'%column
+        assert column in default_value, 'must specify --default-value for column=%s when --branches-basename is not None'%column
 
 if args.branches_dir is None:
     args.branches_dir = args.eos_dir ### fall back if not specified otherwise

--- a/bin/process2samples
+++ b/bin/process2samples
@@ -38,14 +38,14 @@ rgroup.add_argument('-R', '--reference-value-column', default=[], type=str, acti
 
 rgroup.add_argument('--selection-rule', default=samples.DEFAULT_SELECTION_RULE, type=str,
     help='the rule used to choose between multiple values if the the curves are not one-to-one. \
-Must be one of: '%(', '.join(samples.KNOWN_SELECTION_RULES)))
+Must be one of: %s'%(', '.join(samples.KNOWN_SELECTION_RULES)))
 
 rgroup.add_argument('--branches-basename', nargs=4, type=str, default=None,
     help='if specified, will only select from stable branches. This must be a basename template that points to a summary of stable branches \
 along with column names to map the parameters in the eos files (--eos-basename) to the start/end parameters in the branches summary. \
 Note that the column used to look up branches should be monotonically increasing so that it uniquely defines each branch according to the contained range. \
-eg "--branches-basename \'macro-draw-%(draw)06d-branches.csv baryon_density start_central_baryon_density end_central_baryon_density"')
-    help='only select from stable branches. Primarily relevant when looking at multivalued curves')
+eg "--branches-basename \'branches_summary_template baryon_density start_central_baryon_density end_central_baryon_density"')
+
 rgroup.add_argument('--default-value', nargs=2, type=str, action='append', default=[],
     help='the default value to return if the reference is not on a stable branch but --select-from-stable-branches is specified. \
 Should be specified separately for each column that we wish to extract. eg "--default-value Lambda 0.0"')
@@ -144,7 +144,7 @@ ans[:,Nkeep+1:] = samples.process2samples(
     verbose=args.Verbose,
     selection_rule=args.selection_rule,
     branches_mapping=args.branches_template,
-    default_values=args.default_values,
+    default_values=[args.default_values[col] for col in args.columns],
 )
 
 ### set up output columns

--- a/universality/properties/samples.py
+++ b/universality/properties/samples.py
@@ -308,10 +308,12 @@ def process2samples(
         else:
             branches = None
 
+        x_test = static_x_test + (list(dynamic_x_test[i]) if dynamic_x_test is not None else [])
+
         ans[i] = data2samples(
             x,
             d,
-            static_x_test+list(dynamic_x_test[i]),
+            x_test,
             selection_rule=selection_rule,
             branches=branches,
             default_values=default_values,

--- a/universality/properties/samples.py
+++ b/universality/properties/samples.py
@@ -14,6 +14,17 @@ from universality import stats
 
 #-------------------------------------------------
 
+KNOWN_SELECTION_RULES = [
+    'random',
+    'min',
+    'max',
+    'nearest_neighbor',
+]
+
+DEFAULT_SELECTION_RULE = KNOWN_SELECTION_RULES[0]
+
+#------------------------
+
 DEFAULT_COLUMN_NAME = {
     'identity': '%(fcolumn)s',
     'add': '(%(fcolumn)s)+(%(xcolumn)s)',
@@ -114,7 +125,7 @@ def process_calculus(
 # utility functions for processing process directory structures
 #-------------------------------------------------
 
-def data2samples(x, data, static, dynamic, nearest_neighbor=False):
+def data2samples(x, data, static, dynamic, selection_rule=DEFAULT_SELECTION_RULE):
     """logic for exactly how we extract samples from (possibly non-monotonic) data
     """
     Nref, static_x_test = static
@@ -122,6 +133,11 @@ def data2samples(x, data, static, dynamic, nearest_neighbor=False):
 
     Ndata, Ncols = data.shape
     ans = np.empty((Nref+Ndyn)*Ncols, dtype=float)
+
+    nearest_neighbor = (selection_rule == 'nearest_neighbor')
+
+    if not nearest_neighbor:
+        raise NotImplementedError('need to code up other selection rules!')
 
     if nearest_neighbor:
         if Nref > 0:
@@ -178,13 +194,18 @@ def process2samples(
         static_x_test=None,
         dynamic_x_test=None,
         verbose=False,
-        nearest_neighbor=False,
+        selection_rule=DEFAULT_SELECTION_RULE,
+        branches_mapping=None,
+        default_values=None,
     ):
     """manages I/O and extracts samples at the specified places
     returns an array that is ordered as follows
         for each ycolumn: for each static x_test
     """
     loadcolumns = [xcolumn] + ycolumns
+
+    if branches_mapping is not None:
+        raise NotImplementedError('need to code up a way to read out only the stable branches')
 
     if static_x_test is not None:
         Nref = len(static_x_test)
@@ -210,7 +231,7 @@ def process2samples(
         x = d[:,c.index(xcolumn)]
         d = d[:,1:]
 
-        ans[i] = data2samples(x, d, (Nref, static_x_test), (Ndyn, dynamic_x_test[i]), nearest_neighbor=nearest_neighbor)
+        ans[i] = data2samples(x, d, (Nref, static_x_test), (Ndyn, dynamic_x_test[i]), selection_rule=selection_rule)
 
     return ans
 


### PR DESCRIPTION
This patch fixes a bug in process2samples associated with extracting the values from multivalued functions.

  * [x] implement `selection_rule` within process2samples
  * [x] implement `branches_mapping` within process2samples, including the use of default values
  * [x] unify the implementation within `plot-process` and `process2quantiles` with this approach 
    * [x] update `samples.process2quantiles` to delegate to `samples.process2samples` as needed
    * [x] update command-line options for `plot-process` and `process2quantiles`
  * [x] TEST all implementations!