### PR TITLE
misc fixes

### DIFF
--- a/bin/extract-samples
+++ b/bin/extract-samples
@@ -77,8 +77,6 @@ N = len(data)
 if args.verbose:
     print('extacting data at reference values')
 
-ans = np.empty((N, Nref*Ncol), dtype=float)
-
 ans = samples.data2samples(
     x,
     data,
@@ -93,4 +91,4 @@ outcols = samples.outputcolumns(args.columns, args.reference, reference_values=a
 
 if args.verbose:
     print('writing samples to: '+args.outpath)
-io.write(args.outpath, ans, outcols)
+io.write(args.outpath, [ans], outcols)

--- a/bin/extract-samples
+++ b/bin/extract-samples
@@ -6,9 +6,14 @@ __author__ = "Reed Essick (reed.essick@gmail.com)"
 
 #-------------------------------------------------
 
+import os
+
+import numpy as np
+
 from argparse import ArgumentParser
 
 from universality.properties import samples
+from universality.utils import io
 
 #-------------------------------------------------
 
@@ -29,8 +34,8 @@ rgroup.add_argument('-r', '--reference-value', default=[], type=float, action='a
 DEFAULT=[]')
 
 rgroup.add_argument('--selection-rule', default=samples.DEFAULT_SELECTION_RULE, type=str)
-rgroup.add_argument('--branches', nargs=4, type=str, default=None,
-    help='eg "--branches path affine start stop"')
+#rgroup.add_argument('--branches', nargs=4, type=str, default=None,
+#    help='eg "--branches path affine start stop"')
 rgroup.add_argument('--default-value', nargs=2, type=str, default=[], action='append')
 
 # verbosity arguments
@@ -51,9 +56,10 @@ if os.path.dirname(args.outpath) and (not os.path.exists(os.path.dirname(args.ou
     os.makedirs(os.path.dirname(args.outpath))
 
 default_value = dict((key, float(val)) for key, val in args.default_value)
-if args.branches is not None:
-    for column in args.columns:
-        assert column in default_value, 'must specify --default-value for column=%s when --branches-basename is not None'%column
+
+#if args.branches is not None:
+#    for column in args.columns:
+#        assert column in default_value, 'must specify --default-value for column=%s when --branches-basename is not None'%column
 
 #-------------------------------------------------
 
@@ -78,11 +84,10 @@ ans = samples.data2samples(
     data,
     args.reference_value,
     selection_rule=args.selection_rule,
-    branches_mapping=args.branches,
-    default_values=[default_value[col] for col in args.columns],
+    default_values=[default_value.get(col, None) for col in args.columns],
 )
 
-outcols = samples.output_columns(args.columns, args.reference, reference_values=args.reference_value)
+outcols = samples.outputcolumns(args.columns, args.reference, reference_values=args.reference_value)
 
 #------------------------
 

--- a/universality/plot/corner.py
+++ b/universality/plot/corner.py
@@ -43,6 +43,7 @@ def kde_corner(
         verbose=False,
         grid=True,
         color=plt.DEFAULT_COLOR1,
+        color1D=None,
         truth_color=plt.DEFAULT_TRUTH_COLOR,
         truth_alpha=plt.DEFAULT_ALPHA,
         truth_linestyle=plt.DEFAULT_LINESTYLE,
@@ -116,6 +117,13 @@ def kde_corner(
 
     if band_color is None:
         band_color = truth_color
+
+    if not isinstance(color, str):
+        assert len(color) == len(levels), 'must specify one color for each level if color is not a string'
+
+    if color1D is None:
+        assert isinstance(color, str), 'if color is not a string, must specify color1D separately'
+        color1D = color
 
     ### construct figure and axes objects
     if fig is None:
@@ -193,31 +201,31 @@ def kde_corner(
                     kde /= np.sum(kde)*dvects[col]
                     if rotate and row==(Ncol-1): ### rotate the last histogram
                         if filled1D:
-                            ax.fill_betweenx(vects[col], kde, np.zeros_like(kde), color=color, linewidth=linewidth, linestyle=linestyle, alpha=filled_alpha)
-                        ax.plot(kde, vects[col], color=color, linewidth=linewidth, linestyle=linestyle, alpha=alpha)
+                            ax.fill_betweenx(vects[col], kde, np.zeros_like(kde), color=color1D, linewidth=linewidth, linestyle=linestyle, alpha=filled_alpha)
+                        ax.plot(kde, vects[col], color=color1D, linewidth=linewidth, linestyle=linestyle, alpha=alpha)
                         xmax = max(ax.get_xlim()[1], np.max(kde)*1.05)
                         if hist1D:
-                            n, _, _ = ax.hist(data[:,col], bins=bins[col], histtype='step', color=color, normed=True, weights=weights, orientation='horizontal')
+                            n, _, _ = ax.hist(data[:,col], bins=bins[col], histtype='step', color=color1D, normed=True, weights=weights, orientation='horizontal')
                             xmax = max(xmax, np.max(n)*1.05)
 
                         for m, M in lines:
-                            ax.plot([0, 10*xmax], [m]*2, color=color, alpha=alpha, linestyle='dashed') ### plot for a bigger range incase axes change later
-                            ax.plot([0, 10*xmax], [M]*2, color=color, alpha=alpha, linestyle='dashed')
+                            ax.plot([0, 10*xmax], [m]*2, color=color1D, alpha=alpha, linestyle='dashed') ### plot for a bigger range incase axes change later
+                            ax.plot([0, 10*xmax], [M]*2, color=color1D, alpha=alpha, linestyle='dashed')
 
                         ax.set_xlim(xmin=0, xmax=xmax)
 
                     else:
                         if filled1D:
-                            ax.fill_between(vects[col], kde, np.zeros_like(kde), color=color, linewidth=linewidth, linestyle=linestyle, alpha=filled_alpha)
-                        ax.plot(vects[col], kde, color=color, linewidth=linewidth, linestyle=linestyle, alpha=alpha)
+                            ax.fill_between(vects[col], kde, np.zeros_like(kde), color=color1D, linewidth=linewidth, linestyle=linestyle, alpha=filled_alpha)
+                        ax.plot(vects[col], kde, color=color1D, linewidth=linewidth, linestyle=linestyle, alpha=alpha)
                         ymax = max(ax.get_ylim()[1], np.max(kde)*1.05)
                         if hist1D:
-                            n, _, _ = ax.hist(data[:,col], bins=bins[col], histtype='step', color=color, normed=True, weights=weights)
+                            n, _, _ = ax.hist(data[:,col], bins=bins[col], histtype='step', color=color1D, normed=True, weights=weights)
                             ymax = max(ymax, np.max(n)*1.05)
 
                         for m, M in lines:
-                            ax.plot([m]*2, [0, 10*ymax], color=color, alpha=alpha, linestyle='dashed') ### plot for bigger range in case axes change later
-                            ax.plot([M]*2, [0, 10*ymax], color=color, alpha=alpha, linestyle='dashed')
+                            ax.plot([m]*2, [0, 10*ymax], color=color1D, alpha=alpha, linestyle='dashed') ### plot for bigger range in case axes change later
+                            ax.plot([M]*2, [0, 10*ymax], color=color1D, alpha=alpha, linestyle='dashed')
 
                         ax.set_ylim(ymin=0, ymax=ymax)
 
@@ -267,8 +275,7 @@ def kde_corner(
                 plt.setp(ax.get_xticklabels(), rotation=rotate_xticklabels)
             elif rotate and row==(Ncol-1):
                 ax.set_ylim(ranges[row])            
-                plt.setp(ax.get_xticklabels(), rotation=rotate_xticklabels)
-                ax.set_xticks([])
+                ax.set_xticks([]) # no ticks shown
             else:
                 ax.set_xlim(ranges[col])
                 plt.setp(ax.get_xticklabels(), rotation=rotate_xticklabels)
@@ -290,7 +297,9 @@ def kde_corner(
                     twinx.set_yticklabels(ticklabels)
                     twinx.set_ylim(ranges[col])
                     twinx.set_ylabel(label)
- 
+
+                    plt.setp(twinx.get_yticklabels(), rotation=rotate_xticklabels)
+
                 else:
                     twiny = ax.twiny()
                     twiny.tick_params(**plt.TICK_PARAMS)
@@ -303,6 +312,8 @@ def kde_corner(
                     twiny.set_xticklabels(ticklabels)
                     twiny.set_xlim(ranges[col])
                     twiny.set_xlabel(label)
+
+                    plt.setp(ax.get_xticklabels(), rotation=rotate_xticklabels)
 
             # add Truth annotations
             if truths[col] is not None:

--- a/universality/properties/samples.py
+++ b/universality/properties/samples.py
@@ -217,7 +217,10 @@ along each branch when interpolating!')
         # fill in default values as needed
         for i, val in enumerate(vals): ### one for each x_test
             if len(val) == 0: ### x_test not found on any branch!
-                assert (default_values is not None) and (len(default_values) == Ncols), 'default_values must be specified if x_test is not on any branch!'
+                assert (default_values is not None), 'must specify default_values if x_test is not on any branch!'
+                assert (len(default_values) == Ncols) and (not any([val==None for val in default_values])), \
+                    'must specify a default value for each requested column if x_test is not on any branch!'
+
                 vals[i] = [default_values]
 
         # pick from the branches at random (independently for each x_test)


### PR DESCRIPTION
Fixed an issue where we silently got nans returned as part of data2samples (failed to identify when default values were not specified).

Also incorporated suggestions from #40 and #39.
  * separate colors for each contour in corner plots can be passed as a list via the `color` kwarg. There is now a separate kwarg to specify the color of the 1D distributions (cleverly called `color1D` to match the style of `filled` and `filled1D`), which is required if `color` is not a string.
  * rotate the twin'd axes labels if specifying alternate_units
  * updated logic for computing the entropy to explicitly deal with the normalization.

